### PR TITLE
Update gnuhealth_setup.pm

### DIFF
--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -22,7 +22,7 @@ sub run() {
     become_root;
     systemctl 'start postgresql';
     wait_screen_change { script_run 'su postgres', 0 };
-    script_run 'sed -i -e \'s/\(\(local\|host\).*all.*all.*\)\(md5\|ident\)/\1trust/g\' /var/lib/pgsql/data/pg_hba.conf', 0;
+    script_run 'sed -i -e \'s/\(\(local\|host\).*all.*all.*\)\(md5\|peer\|ident\)/\1trust/g\' /var/lib/pgsql/data/pg_hba.conf', 0;
     script_run 'psql -c "CREATE USER tryton WITH CREATEDB;"',                                                             0;
     if (is_tumbleweed || is_leap('42.3+')) {
         script_run 'createdb gnuhealth --encoding=\'UTF8\' --owner=tryton', 0;
@@ -31,11 +31,12 @@ sub run() {
     systemctl 'restart postgresql';
     # generate the crypted password as described in /etc/tryton/trytond.conf
     # but with no randomness for easier testing and preventing a stray '/' to
-    # destroy the sed call
-    script_run 'pw=$(python -c \'import getpass,crypt; print(crypt.crypt(getpass.getpass(), str(123456789)))\')', 0;
-    wait_still_screen(1);
+    # destroy the sed call     
+    # Superpassword is not supported since tryton 4.0
+    # script_run 'pw=$(python -c \'import getpass,crypt; print(crypt.crypt(getpass.getpass(), str(123456789)))\')', 0;
+    # wait_still_screen(1);
     type_string "susetesting\n";
-    assert_script_run 'sed -i -e "s/^.*super_pwd.*\$/super_pwd = ${pw}/g" /etc/tryton/trytond.conf';
+    #assert_script_run 'sed -i -e "s/^.*super_pwd.*\$/super_pwd = ${pw}/g" /etc/tryton/trytond.conf';
     if (is_tumbleweed || is_leap('42.3+')) {
         assert_script_run 'echo susetesting > /tmp/pw';
         assert_script_run 'sudo -u tryton env TRYTONPASSFILE=/tmp/pw trytond-admin -c /etc/tryton/trytond.conf --all -d gnuhealth --password', 600;


### PR DESCRIPTION
add peer to trust parameters to be changed
remove super passwd handling (not supported in Tryton 4.2

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
